### PR TITLE
Add skeleton for Azure Bakery (Only deploys a Resource Group)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+## What I am changing
+
+## How I did it
+
+## How you can test it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  linting:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019]
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.15.0
+
+      - name: Initialising
+        run: |
+          make init
+        shell: bash
+
+      - name: Linting
+        run: |
+          make lint
+        shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,7 @@ on:
 
 jobs:
   linting:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, windows-2019]
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 
@@ -21,9 +18,7 @@ jobs:
       - name: Initialising
         run: |
           make init
-        shell: bash
 
       - name: Linting
         run: |
           make lint
-        shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+
+# Created by https://www.toptal.com/developers/gitignore/api/terraform
+# Edit at https://www.toptal.com/developers/gitignore?templates=terraform
+
+### Terraform ###
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# End of https://www.toptal.com/developers/gitignore/api/terraform
+
+deployment.tfvars.json

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONEY: install lint format plan apply destroy
+.PHONEY: init lint format plan apply destroy
 
-install:
+init:
 	terraform -chdir="terraform/" init
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONEY: install lint format plan apply destroy
+
+install:
+	terraform -chdir="terraform/" init
+
+lint:
+	terraform -chdir="terraform/" validate
+
+format:
+	terraform -chdir="terraform/" fmt
+
+plan:
+	terraform -chdir="terraform/" plan -var-file="../deployment.tfvars.json"
+
+apply:
+	terraform -chdir="terraform/" apply -auto-approve -var-file="../deployment.tfvars.json"
+
+destroy:
+	terraform -chdir="terraform/" destroy -auto-approve -var-file="../deployment.tfvars.json"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,165 @@
-# pangeo-forge-azure-bakery
-pangeo-forge bakery for running pangeo-forge recipes on Azure
+# pangeo-forge Azure Bakery ☁️🍞
+
+This repository serves as the provider of an Terraform Application which deploys the necessary infrastructure to provide a `pangeo-forge` Bakery on Azure
+
+# Contents
+
+* [🧑‍💻 Development - Requirements](#requirements)
+* [🧑‍💻 Development - Getting Started](#getting-started-🏃‍♀️)
+
+# Development
+
+## Requirements
+
+To develop on this project, you should have the following installed:
+
+* [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
+* [Terraform 0.15.0](https://www.terraform.io/downloads.html)
+
+If you're developing on MacOS, all of the above can be installed using [homebrew](https://brew.sh/)
+
+If you're developing on Windows, we'd recommend using either [Git BASH](https://gitforwindows.org/) or [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
+
+
+## Getting Started 🏃‍♀️
+
+### Azure Credential setup
+
+To develop and deploy this project, you will first need to setup some credentials and permissions on Azure; before doing this ensure you've installed the [requirements](#requirements) listed above.
+
+#### Logging in
+
+With the Azure CLI installed, run:
+
+```bash
+$ az login # Opens up a browser window to login with
+[
+  {
+    "cloudName": "AzureCloud",
+    "homeTenantId": "<a-home-tenant-id>",
+    "id": "<a-id>",
+    "isDefault": true,
+    "managedByTenants": [],
+    "name": "SuperAwesomeSubscription",
+    "state": "Enabled",
+    "tenantId": "<a-tenant-id>",
+    "user": {
+      "name": "<your-username>",
+      "type": "user"
+    }
+  },
+  ...
+]
+```
+
+If you notice that the `Subscription` you intend to use has `"isDefault": false`, then refer to [this documentation](https://docs.microsoft.com/en-us/cli/azure/manage-azure-subscriptions-azure-cli#change-the-active-subscription) on how to switch your default `Subsciption`.
+
+#### Creating a Service Principal
+
+You will then need to create a `Service Principal` to deploy as:
+
+```bash
+$ az ad sp create-for-rbac --name "<name-for-your-service-principal>"
+{
+  "appId": "<an-app-id>",
+  "displayName": "<name-for-your-service-principal>",
+  "name": "http://<name-for-your-service-principal>",
+  "password": "<a-password>",
+  "tenant": "<a-tenant-id>"
+}
+```
+
+Keep note of the values of `appId` and `password`.
+
+#### Adding Service Principal permissions
+
+Your service principal will need a few permissions added to it, for these you'll need to get its `objectId`, you can get this by running:
+
+```bash
+$ az ad sp list --display-name "<name-for-your-service-principal>"
+[
+  {
+    "accountEnabled": "True",
+    "addIns": [],
+    "alternativeNames": [],
+    "appDisplayName": "<name-for-your-service-principal>",
+    "appId": "<a-app-id>",
+    "appOwnerTenantId": "<a-tenant-id>",
+    "appRoleAssignmentRequired": false,
+    "appRoles": [],
+    "applicationTemplateId": null,
+    "deletionTimestamp": null,
+    "displayName": "<name-for-your-service-principal>",
+    "errorUrl": null,
+    "homepage": "https://<name-for-your-service-principal>",
+    "informationalUrls": {
+      "marketing": null,
+      "privacy": null,
+      "support": null,
+      "termsOfService": null
+    },
+    "keyCredentials": [],
+    "logoutUrl": null,
+    "notificationEmailAddresses": [],
+    "oauth2Permissions": [
+      {
+        "adminConsentDescription": "Allow the application to access <name-for-your-service-principal> on behalf of the signed-in user.",
+        "adminConsentDisplayName": "Access <name-for-your-service-principal>",
+        "id": "<an-id>",
+        "isEnabled": true,
+        "type": "User",
+        "userConsentDescription": "Allow the application to access <name-for-your-service-principal> on your behalf.",
+        "userConsentDisplayName": "Access <name-for-your-service-principal>",
+        "value": "user_impersonation"
+      }
+    ],
+    "objectId": "<a-object-id>",
+    "objectType": "ServicePrincipal",
+    "odata.type": "Microsoft.DirectoryServices.ServicePrincipal",
+    "passwordCredentials": [],
+    "preferredSingleSignOnMode": null,
+    "preferredTokenSigningKeyEndDateTime": null,
+    "preferredTokenSigningKeyThumbprint": null,
+    "publisherName": "<a-publisher-name>",
+    "replyUrls": [],
+    "samlMetadataUrl": null,
+    "samlSingleSignOnSettings": null,
+    "servicePrincipalNames": [
+      "http://<name-for-your-service-principal>",
+      "<a-service-principal-id>"
+    ],
+    "servicePrincipalType": "Application",
+    "signInAudience": "AzureADMyOrg",
+    "tags": [],
+    "tokenEncryptionKeyId": null
+  }
+]
+```
+
+From the resultant JSON output to the screen, copy the value of `objectID`.
+
+You can then run:
+
+```bash
+$ az role assignment create --assignee "<objectId>" --role "Storage Blob Data Contributor"
+$ az role assignment create --assignee "<objectId>" --role "User Access Administrator"
+$ az role assignment create --assignee "<objectId>" --role  "Azure Kubernetes Service Cluster User Role"
+```
+
+You should now be setup with the correct permissions to deploy the infrastructure onto Azure. Further reading on Azure Service Principals can be found [here](https://docs.microsoft.com/en-us/cli/azure/ad/sp?view=azure-cli-latest).
+
+### `deployment.tfvars.json` file
+
+A `deployment.tfvars.json` file is expected at the root of the repository to store variables used within deployment, the expected values are:
+
+```bash
+{
+    "owner": "<your-name>",
+    "identifier": "<a-unique-value-to-tie-to-your-deployment>",
+    "region": "<azure-region-name-to-deploy-to>",
+    "appId": "<value-of-appId-from-earlier>",
+    "password": "<value-of-password-from-earlier>"
+}
+```
+
+An example called `example.tfvars.json` is available for you to copy, rename, and fill out accordingly.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository serves as the provider of an Terraform Application which deploys
 
 * [🧑‍💻 Development - Requirements](#requirements)
 * [🧑‍💻 Development - Getting Started](#getting-started-🏃‍♀️)
+* [🧑‍💻 Development - Makefile goodness](#makefile-goodness)
+* [🚀 Deployment - Standard Deployments](#standard-deployments)
 
 # Development
 
@@ -163,3 +165,52 @@ A `deployment.tfvars.json` file is expected at the root of the repository to sto
 ```
 
 An example called `example.tfvars.json` is available for you to copy, rename, and fill out accordingly.
+
+## Makefile goodness
+
+A `Makefile` is available in the root of the repository to abstract away commonly used commands for development:
+
+**`make init`**
+
+> This will run `terraform init` within the `terraform/` directory, installing any providers required for deployment
+
+**`make lint`**
+
+> This will run `terraform validate` within the `terraform/` directory, showing you anything that is incorrect in your Terraform scripts
+
+**`make format`**
+
+> This will run `terraform fmt` within the `terraform/` directory, this **will** modify files if issues were found
+
+**`make plan`**
+
+> This will run `terraform plan` within the `terraform/` directory using the contents of your `deployment.tfvars.json` file
+
+**`make apply`**
+
+> This will run `terraform apply` within the `terraform/` directory using the contents of your `deployment.tfvars.json` file. The deployment is auto-approved, so **make sure** you know what you're changing with your deployment first! (Best to run `make plan` to check!)
+
+**`make destroy`**
+
+> This will run `terraform destroy` within the `terraform/` directory using the contents of your `deployment.tfvars.json` file. The destroy is auto-approved, so **make sure** you know what you're destroying first!
+
+# Deployment
+
+## Standard Deployments
+
+For standard deploys, you can check _what_ you'll be deploying by running:
+
+```bash
+$ make plan # Outputs the result of `terraform plan`
+```
+
+To deploy the infrastructure, you can run:
+
+```bash
+$ make apply # Deploys the Bakery
+```
+
+To destroy the infrastructure, you can run:
+
+```bash
+$ make destroy # Destroys the Baker

--- a/README.md
+++ b/README.md
@@ -158,9 +158,7 @@ A `deployment.tfvars.json` file is expected at the root of the repository to sto
 {
     "owner": "<your-name>",
     "identifier": "<a-unique-value-to-tie-to-your-deployment>",
-    "region": "<azure-region-name-to-deploy-to>",
-    "appId": "<value-of-appId-from-earlier>",
-    "password": "<value-of-password-from-earlier>"
+    "region": "<azure-region-name-to-deploy-to>"
 }
 ```
 

--- a/example.tfvars.json
+++ b/example.tfvars.json
@@ -1,7 +1,5 @@
 {
     "owner": "<your-name>",
     "identifier": "<a-unique-value-to-tie-to-your-deployment>",
-    "region": "<azure-region-name-to-deploy-to>",
-    "appId": "<value-of-appId-from-earlier>",
-    "password": "<value-of-password-from-earlier>"
+    "region": "<azure-region-name-to-deploy-to>"
 }

--- a/example.tfvars.json
+++ b/example.tfvars.json
@@ -1,0 +1,7 @@
+{
+    "owner": "<your-name>",
+    "identifier": "<a-unique-value-to-tie-to-your-deployment>",
+    "region": "<azure-region-name-to-deploy-to>",
+    "appId": "<value-of-appId-from-earlier>",
+    "password": "<value-of-password-from-earlier>"
+}

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "2.56.0"
+  constraints = "2.56.0"
+  hashes = [
+    "h1:nTw9fg12T1tsASm+jqBUVABfxe7Tje+5ho7vbBavU4Y=",
+    "zh:1994185185046df38eb1d1ad3c3b07e4f964224e4ab756957473b754f6aec75c",
+    "zh:202556c142f001830dd4514d475dc747f863ad588382c43daa604d53761f59f5",
+    "zh:3010bcf9ebe33e1195f0a7507183959918c6b88bbdc84c8cc96919654e0abcb0",
+    "zh:39ff556080515b170b10f365a0f95abf2590e9ca3d79261defea1e3133e79088",
+    "zh:500d4e787bf046bbe64c4853530aff3dfddee2fdbff0087d7b1e7a8c24388628",
+    "zh:766ff42596d643f9945b3aab2e83e306fe77c3020a5196366bbbb77eeea13b71",
+    "zh:8a7a6548a383a12aa137b0441c15fc7243a1d3e4fd8a9292946ef423d2d8bcff",
+    "zh:bb9f5e9289df17a7a07bdd3add79e41a195e3d129c2ab974b5bb6272c9812068",
+    "zh:ce72eaaecccb50f52f50c69ed3261b0a4050b846f2e664d120d30dfeb65067bc",
+    "zh:d10b33dd19316ef10965ad0fb8ca6f2743bceaf5167bd8e6e25815e20786f190",
+    "zh:fe5aba92430104238f66aaaf02acf323d457d387cd33d6b3d8c6fdd9e449b834",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,15 +15,15 @@ provider "azurerm" {
 
 locals {
   tags = {
-    "Project": "pangeo-forge-azure-bakery",
-    "Client": "Planetary Computer",
-    "Owner": var.owner,
-    "Stack": var.identifier
+    "Project" : "pangeo-forge-azure-bakery",
+    "Client" : "Planetary Computer",
+    "Owner" : var.owner,
+    "Stack" : var.identifier
   }
 }
 
 resource "azurerm_resource_group" "bakery_resource_group" {
   name     = "${var.identifier}-resource-group"
   location = var.region
-  tags = local.tags
+  tags     = local.tags
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = ">= 0.15.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "2.56.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  tags = {
+    "Project": "pangeo-forge-azure-bakery",
+    "Client": "Planetary Computer",
+    "Owner": var.owner,
+    "Stack": var.identifier
+  }
+}
+
+resource "azurerm_resource_group" "bakery_resource_group" {
+  name     = "${var.identifier}-resource-group"
+  location = var.region
+  tags = local.tags
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,7 +3,3 @@ variable "owner" {}
 variable "identifier" {}
 
 variable "region" {}
-
-variable "appId" {}
-
-variable "password" {}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,9 @@
+variable "owner" {}
+
+variable "identifier" {}
+
+variable "region" {}
+
+variable "appId" {}
+
+variable "password" {}


### PR DESCRIPTION
## What I am changing

TL;DR: This PR creates the shell for the `pangeo-forge-azure-bakery` repository. It provides instructions on setting up the Azure credentials etc needed for a deployment, provides a very small deployable of a named & tagged resource group, and it provides a very basic Github Actions workflow for linting

## How I did it

* Add `terraform/`
    * `main.tf` currently just sets up the `azurerm` provider, the tags, and the named resource group
    * `variables.tf` declares the variables needed during deployment (Populated from `deployment.tfvars.json`)
* Add README
    * Highlights requirements for deploying the Bakery (so far)
    * Provides instructions on authenticating with Azure CLI and then creating the Service Principal for deployment
    * Provides instructions on creating `deployment.tfvars.json`
    * Gives an overview of the provided `Makefile` and the deployment process
* Add `.github/`
    * Adds PR Template
    * Adds simple Github Actions workflow that installs Terraform, initialises it then lints.
    
## How you can test it

Firstly I'd recommend checking out this branch, installing the requirements, and following the Azure setup instructions. From there, you can then run:

```bash
$ make plan
```

To see what you would deploy, you can then run:

```bash
$ make apply
```

To deploy the current stack, which is just a named resource group: `<identifier>-resource-group`, you can then destroy it with:

```bash
$ make destroy
```
