### PR TITLE
feat: add autoscaler profile to leave unused nodes spinning for less time

### DIFF
--- a/terraform/cluster.tf
+++ b/terraform/cluster.tf
@@ -15,7 +15,7 @@ resource "azurerm_kubernetes_cluster" "bakery_cluster" {
 
   auto_scaler_profile {
     scale_down_delay_after_add = "2m"
-    scale_down_unneeded = "2m"
+    scale_down_unneeded        = "2m"
   }
 
   identity {


### PR DESCRIPTION
## What I am changing
I am enabling the autoscaler profiling as detailed here https://docs.microsoft.com/en-us/azure/aks/cluster-autoscaler#using-the-autoscaler-profile

## How I did it
Added the `auto_scaler_profile` block to the AKS cluster

## How you can test it
- Deploy a bakery
- Force a scale up by doing a run
- Watch the nodepool scale back down once it is done
