### PR TITLE
feat: autodeploy grafana with loki

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,16 +217,11 @@ Flow URL: https://cloud.prefect.io/<your-account>/flow/aef82344-8a31-485b-a189-b
 2. To view pods in your pangeoforge namespace click workloads and select the namespace you specified when deploying.
 3. Verify your Prefect agent pod is healthy.
 
-### To view Dask cluster logs via Grafana  
+
+### To view Dask cluster logs via Grafana
 1. Get the info needed to access the Grafana instance with `make get-grafana-admin`.
 2. Use Lens to connect to Grafana by navigating Network -> Services and click `loki-grafana` and then click the `80:3000/TCP` link and use username `admin` and the password obtained in step 1.
-3. Add the Loki datasource in Grafana.  
-   1. Click the the configuration incon on the left
-   2. Click Add Datasource
-   3. Select Loki
-   4. The URL of the Loki Stack is `http://loki-stack.loki-stack.svc.cluster.local:3100`
-   5. Click Save and Test
-4. Browsing logs
+3. Browsing logs
    1. Return to the main page and select the Explore icon on the left.
    2. Click Log Browser.
    3. After running a test flow via `make test-flow` use `make getinfo` to view a list of flow runs.

--- a/scripts/loki.sh
+++ b/scripts/loki.sh
@@ -21,9 +21,4 @@ echo "- Deploying the loki stack"
 helm install loki-stack grafana/loki-stack \
                                 --create-namespace \
                                 --namespace loki-stack \
-                                --set promtail.enabled=true,loki.persistence.enabled=true,loki.persistence.size=100Gi
-
-echo "- Deploying loki-grafana"
-helm install loki-grafana grafana/grafana \
-                              --set persistence.enabled=true,persistence.type=pvc,persistence.size=10Gi \
-                              --namespace=loki-stack
+                                --set promtail.enabled=true,loki.persistence.enabled=true,loki.persistence.size=100Gi,grafana.enabled=true


### PR DESCRIPTION
## What I am changing
I am making loki deploy grafana itself, and setup the relevant datasource

## How I did it
I passed the `grafana.enabled` option to lokistack

## How you can test it
run `make deploy` and test grafana
